### PR TITLE
Fix package main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/matanlurey/tts-save-format.git"
   },
-  "main": "src/index.d.ts",
+  "main": "src/types.d.ts",
   "author": "Matan Lurey",
   "keywords": [
     "Tabletop",


### PR DESCRIPTION
Currently `import { ... } from "@matanlurey/tts-save-files"` raises an error and `import { ... } from "@matanlurey/tts-save-files/src/types"` needs to be referenced explicitly